### PR TITLE
Added option to scale pitch with transaction size

### DIFF
--- a/engine.css
+++ b/engine.css
@@ -91,13 +91,13 @@ a {
 
 #volumeWrapper {
 	position: fixed;
-	bottom: 0;
+	bottom: 24px;
 	right: 0;
 	margin: 2em;
 }
 
 #volumeControl {
-	background-image: url('images/sound.png');
+	background: url('images/sound.png') right;
 	background-position: 0 -46px;
 	cursor: pointer;
 	width: 50px;
@@ -115,6 +115,14 @@ a {
 	bottom: 66px;
 	display: block;
 	right: 20px;
+}
+
+#soundControls {
+	position: fixed;
+	bottom: 0;
+	right: 0;
+	margin: 2em;
+	color: white;
 }
 
 #hideInterface {

--- a/index.html
+++ b/index.html
@@ -76,9 +76,18 @@
 				</p>
 			</div>
 		</div>
-		<div id="volumeWrapper"class="interface">
+		<div id="volumeWrapper" class="interface">
 			<div id="volumeControl"></div>
 			<div id="volumeSlider" class="noUiSlider"></div>
+		</div>
+		<div id="soundControls" class="interface">
+			<div id="scalePitch" class="monospace">
+				<p>
+					<label>
+						<input id="scalePitchCheckBox" type='checkbox' checked="checked" onchange='globalScalePitch = this.checked'>
+						Scale pitch with transaction amount (bigger transaction = deeper sound)</label>
+				</p>
+			</div>
 		</div>
 		<div id="hideInterface" class="serif" onclick='toggleInterface()'>[ Hide Interface ]</div>
 		<div id="noJavascript">

--- a/sound.js
+++ b/sound.js
@@ -1,4 +1,5 @@
 var globalVolume = 100;
+var globalScalePitch = true;
 
 function Sound() {
 
@@ -65,17 +66,40 @@ var noteTimeout = 200;
 Sound.playRandomAtVolume = function(volume) {
 	if (globalMute)
 		return;
-	var randomIndex = Math.floor(Math.random() * this.celesta.length);
+		
+	var randomPitch = Math.floor(Math.random() * 100);
+	this.playPitchAtVolume(volume, randomPitch);
+}
 
-	var readyState = this.celesta[randomIndex].get("readyState");
+Sound.playPitchAtVolume = function(volume, pitch) {
+	if (globalMute)
+		return;
+	
+	// Find the index corresponding to the requested pitch
+	var index = Math.floor(pitch / 100.0 * this.celesta.length);
+	//console.log("Pitch: " + pitch);
+	
+	// Here we fuzz the index a bit to prevent the same sound
+	// from being heard over and over again, which gets annoying
+	var fuzz = Math.floor(Math.random() * 4) - 2;
+	index += fuzz
+	index = Math.min(this.celesta.length - 1, index);
+	index = Math.max(0, index);
+	
+	//console.log("Fuzz: " + fuzz);
+	//console.log("Index: " + index);
+	
+
+	var readyState = this.celesta[index].get("readyState");
 	if (readyState >= 2 && currentNotes < 5) {
-		this.celesta[randomIndex].stop().setVolume(volume * (globalVolume / 100)).play();
+		this.celesta[index].stop().setVolume(volume * (globalVolume / 100)).play();
 		currentNotes++;
 		setTimeout(function() {
 			currentNotes--;
 		}, noteTimeout);
 	}
 }
+
 var lastBlockSound = -1;
 Sound.playRandomSwell = function() {
 	if (globalMute)
@@ -93,4 +117,3 @@ Sound.playRandomSwell = function() {
 	if (readyState >= 2)
 		this.swells[randomIndex].stop().setVolume(globalVolume).play();
 }
-

--- a/transaction.js
+++ b/transaction.js
@@ -28,7 +28,23 @@ function Transaction(bitcoins, highlight, currency, currencyName) {
 	var volume = bitcoins / (maxBitcoins / (maxVolume - minVolume)) + minVolume;
 	if (volume > maxVolume)
 		volume = maxVolume;
-	Sound.playRandomAtVolume(volume * 100);
+	
+	var maxPitch = 100.0;
+	// We need to use a log that makes it so that maxBitcoins reaches the maximum pitch.
+	// Well, the opposite of the maximum pitch. Anyway. So we solve:
+	// maxPitch = log(maxBitcoins + logUsed) / log(logUsed)
+	// For maxPitch = 100 (for 100%) and maxBitcoins = 1000, that gives us...
+	var logUsed = 1.0715307808111486871978099;
+	// So we find the smallest value between log(bitcoins + logUsed) / log(logUsed) and our max pitch...
+	var pitch = Math.min(maxPitch, Math.log(bitcoins + logUsed) / Math.log(logUsed));
+	// ...we invert it so that a bigger transaction = a deeper noise...
+	pitch = maxPitch - pitch;
+	// ...and we play the sound!
+	if(globalScalePitch) {
+		Sound.playPitchAtVolume(volume * 100, pitch);
+	} else {
+		Sound.playRandomAtVolume(volume * 100);
+	}
 }
 
 extend(Floatable, Transaction);


### PR DESCRIPTION
I've seen the suggestion thrown around on reddit, so I took the time to implement it.

There now is a checkbox to enable that option, which will make bigger transaction sound deeper. It'll use a logarithmic scale from 0.01 BTC to 1000 BTC, then it will cap to the deepest sound available. To prevent all small transaction from making the same, high-pitched noise, I added some fuzzing so that the sound played is ± 2 from the actual pitch corresponding to the transaction size.

Thank you for making this site! It's a nice background for me to listen to while working. =)
